### PR TITLE
Make workspace optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 serverless-terraform-outputs
 ============================
 
-Provides variable substitution resolution from Terraform outputs with workspace support:
+Provides variable substitution resolution from Terraform outputs:
+
+```
+${terraform:sqs_queue_stuff.value.arn}
+```
+# Usage
+```yaml
+provider:
+    environment:
+        SQS_QUEUE: ${terraform:sqs_queue_stuff.value.url}
+```
+
+## Workspace support
 ```
 ${terraform:app-stage:sqs_queue_stuff.value.arn}
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,11 @@ class ServerlessTerraformOpts {
     }
 
     async _getValue(variable: string) {
-        const [workspace, path] = variable.split(':')
+        const items = variable.split(':')
+        const path = items.length > 1 ? items[1] : items[0]
+        const workspace = items.length > 1 ? items[0] : undefined
         
-        const outputs = await TFOutputs.Load(workspace, this.serverless)
+        const outputs = await TFOutputs.Load(this.serverless, workspace)
 
         const value = outputs.getValueAtPath(path)
 

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -1,7 +1,7 @@
 import {exec} from './async'
 
 
-export async function output(workspace: string, serverless: any): Promise<any> {
+export async function output(serverless: any, workspace?: string): Promise<any> {
     const pluginOptions = ((serverless.service || {}).custom || {}).terraformOutputs || {}
 
     const options = {
@@ -25,9 +25,9 @@ export class TFOutputs {
      * Use Terraform command to fetch outputs and construct TFOutputs instance.
      * @param workspace Name of Terraform workspace to use
      */
-    static async Load(workspace: string, serverless: any) {
+    static async Load(serverless: any, workspace?: string) {
         if(!this.resp)
-            this.resp = output(workspace, serverless)
+            this.resp = output(serverless, workspace)
         const outputs = await this.resp
         return new TFOutputs(outputs, serverless)
     }


### PR DESCRIPTION
* makes the serverless.yml more readable if you do not make use of workspaces
* if workspaces are used by specifying TF_WORKSPACE, this then is not being overwritten anymore